### PR TITLE
Randomシードの設定フォームを追加する

### DIFF
--- a/app/lib/components/blocks/entry_form.dart
+++ b/app/lib/components/blocks/entry_form.dart
@@ -180,6 +180,7 @@ class EntryForm extends HookConsumerWidget {
                             185,
                             _predictWeightPathController.text,
                             int.parse(_trialNumberController.text),
+                            [0], // invalid random_seed field
                           )
                         );
                       },

--- a/app/lib/components/blocks/entry_form.dart
+++ b/app/lib/components/blocks/entry_form.dart
@@ -180,7 +180,7 @@ class EntryForm extends HookConsumerWidget {
                             185,
                             _predictWeightPathController.text,
                             int.parse(_trialNumberController.text),
-                            [0], // invalid random_seed field
+                            [], // invalid random_seed field
                           )
                         );
                       },

--- a/app/lib/components/blocks/form.dart
+++ b/app/lib/components/blocks/form.dart
@@ -222,6 +222,7 @@ class SubmitForm extends HookConsumerWidget {
                             185,
                             _predictWeightPathController.text,
                             int.parse(_trialNumberController.text),
+                            [0],
                           )
                         );
                       },

--- a/app/lib/components/blocks/form.dart
+++ b/app/lib/components/blocks/form.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../../model/form_model.dart';
 import '../../model/score_evaluation_message.pb.dart';
+import '../parts/random_seed_form.dart';
 import '../../view_model/providers.dart';
 import '../../view_model/form_view_model.dart' as FormViewModel;
 
@@ -25,6 +26,7 @@ class SubmitForm extends HookConsumerWidget {
     final _formCardHeight = _screenSize.height * 0.11;
     final _formCardWidth = _screenSize.width * 0.5;
     final _state = ref.watch(formStateNotifierProvider);
+    final _random_seeds_state = ref.watch(randomSeedsFormStateNotifierProvider);
 
     return Form(
       key: _formKey,
@@ -121,85 +123,116 @@ class SubmitForm extends HookConsumerWidget {
                   ),
                 ),
               ),
-              Card(
-                child: ExpansionTile(
-                title: Text('options'),
-                controlAffinity: ListTileControlAffinity.leading,
-                maintainState: true,
-                children: <Widget>[
-                  Center(
-                    child: SizedBox(
-                      width: _formCardWidth,
-                      height: _formCardHeight,
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'game mode ["default", "predict", "predict_sample", "predict_sample2"]',
+              SizedBox(
+                child: Card(
+                  child: ExpansionTile(
+                    title: Text('options'),
+                    controlAffinity: ListTileControlAffinity.leading,
+                    maintainState: true,
+                    children: <Widget>[
+                      Center(
+                        child: SizedBox(
+                          width: _formCardWidth,
+                          height: _formCardHeight,
+                          child: TextFormField(
+                            decoration: const InputDecoration(
+                              labelText: 'game mode ["default", "predict", "predict_sample", "predict_sample2"]',
+                            ),
+                            controller: _gameModeController,
+                            validator: (String? value) {
+                              List game_modes = ["default", "predict", "predict_sample", "predict_sample2"];
+                              if (!game_modes.contains(value)) {
+                                return 'must be in ${game_modes}';
+                              }
+                              return null;
+                            },
+                          ),
                         ),
-                        controller: _gameModeController,
-                        validator: (String? value) {
-                          List game_modes = ["default", "predict", "predict_sample", "predict_sample2"];
-                          if (!game_modes.contains(value)) {
-                            return 'must be in ${game_modes}';
-                          }
-                          return null;
-                        },
                       ),
-                    ),
-                  ),
-                  Center(
-                    child: SizedBox(
-                      width: _formCardWidth,
-                      height: _formCardHeight,
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'predict weight path',
+                      Center(
+                        child: SizedBox(
+                          width: _formCardWidth,
+                          height: _formCardHeight,
+                          child: TextFormField(
+                            decoration: const InputDecoration(
+                              labelText: 'predict weight path',
+                            ),
+                            controller: _predictWeightPathController,
+                          ),
                         ),
-                        controller: _predictWeightPathController,
                       ),
-                    ),
-                  ),Center(
-                    child: SizedBox(
-                      width: _formCardWidth,
-                      height: _formCardHeight,
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'game time',
+                      Center(
+                        child: SizedBox(
+                          width: _formCardWidth,
+                          height: _formCardHeight,
+                          child: TextFormField(
+                            decoration: const InputDecoration(
+                              labelText: 'game time',
+                            ),
+                            controller: _gameTimeController,
+                            validator: (String? value) {
+                              if (value==null || int.parse(value, onError: (value) => 0)<=0) {
+                                return 'please input positive integer';
+                              } else if (int.parse(value, onError: (value) => 0)>180){
+                                return 'game time cannot be more than 180 s';
+                              }
+                              return null;
+                            },
+                          ),
                         ),
-                        controller: _gameTimeController,
-                        validator: (String? value) {
-                          if (value==null || int.parse(value, onError: (value) => 0)<=0) {
-                            return 'please input positive integer';
-                          } else if (int.parse(value, onError: (value) => 0)>180){
-                            return 'game time cannot be more than 180 s';
-                          }
-                          return null;
-                        },
                       ),
-                    ),
-                  ),
-                  Center(
-                    child: SizedBox(
-                      width: _formCardWidth,
-                      height: _formCardHeight,
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'trial number',
+                      Center(
+                        child: SizedBox(
+                          width: _formCardWidth,
+                          height: _formCardHeight,
+                          child: TextFormField(
+                            decoration: const InputDecoration(
+                              labelText: 'trial number',
+                            ),
+                            controller: _trialNumberController,
+                            validator: (String? value) {
+                              if (value==null || int.parse(value, onError: (value) => 0)<=0) {
+                                return 'please input positive integer';
+                              } else if (int.parse(value, onError: (value) => 0)>10){
+                                return 'trial number cannot be more than 10 ;;';
+                              }
+                              return null;
+                            },
+                          ),
                         ),
-                        controller: _trialNumberController,
-                        validator: (String? value) {
-                          if (value==null || int.parse(value, onError: (value) => 0)<=0) {
-                            return 'please input positive integer';
-                          } else if (int.parse(value, onError: (value) => 0)>10){
-                            return 'trial number cannot be more than 10 ;;';
-                          }
-                          return null;
-                        },
                       ),
-                    ),
-                  ),
-                ],
+                      Center(
+                        child: SizedBox(
+                          width: _formCardWidth,
+                          child: Row(
+                            children: <Widget>[
+                              Text("enable seed configurration"),
+                              Checkbox(
+                                activeColor: Colors.blue,
+                                value: _random_seeds_state.isEnabledSeedConfiguration,
+                                onChanged: ref.read(randomSeedsFormStateNotifierProvider.notifier).toggleIsEnabled,
+                              ),
+                            ]
+                          ),
+                        )
+                      ),
+                      ((){
+                        if (_random_seeds_state.isEnabledSeedConfiguration){
+                          return Center(
+                            child: SizedBox(
+                              width: _formCardWidth,
+                              child: RanomSeedForm()
+                            )
+                          );
+                        }
+                        else{
+                          return SizedBox();
+                        }
+                      })(),
+                    ],
+                  )
                 )
-              ),
+              ),   
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16.0),
                 child: ((){
@@ -222,7 +255,7 @@ class SubmitForm extends HookConsumerWidget {
                             185,
                             _predictWeightPathController.text,
                             int.parse(_trialNumberController.text),
-                            [],
+                            _random_seeds_state.seeds,
                           )
                         );
                       },

--- a/app/lib/components/blocks/form.dart
+++ b/app/lib/components/blocks/form.dart
@@ -222,7 +222,7 @@ class SubmitForm extends HookConsumerWidget {
                             185,
                             _predictWeightPathController.text,
                             int.parse(_trialNumberController.text),
-                            [0],
+                            [],
                           )
                         );
                       },

--- a/app/lib/components/blocks/form.dart
+++ b/app/lib/components/blocks/form.dart
@@ -246,6 +246,10 @@ class SubmitForm extends HookConsumerWidget {
                           ref.read(formStateNotifierProvider.notifier).setFormValidationErrorState();
                           return;
                         }
+                        if (_random_seeds_state.isEnabledSeedConfiguration && (int.parse(_trialNumberController.text)!=_random_seeds_state.seeds.length)){
+                          ref.read(formStateNotifierProvider.notifier).setRandomFormValidationErrorState();
+                          return;
+                        }
                         ref.read(formStateNotifierProvider.notifier).submitMessage(
                           FormModel(
                             _userNameFormController.text,

--- a/app/lib/components/blocks/form.dart
+++ b/app/lib/components/blocks/form.dart
@@ -206,7 +206,7 @@ class SubmitForm extends HookConsumerWidget {
                           width: _formCardWidth,
                           child: Row(
                             children: <Widget>[
-                              Text("enable seed configurration"),
+                              Text("seed configuration"),
                               Checkbox(
                                 activeColor: Colors.blue,
                                 value: _random_seeds_state.isEnabledSeedConfiguration,
@@ -229,10 +229,13 @@ class SubmitForm extends HookConsumerWidget {
                           return SizedBox();
                         }
                       })(),
+                      SizedBox(
+                        height: 30
+                      ),
                     ],
                   )
                 )
-              ),   
+              ),
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16.0),
                 child: ((){

--- a/app/lib/components/blocks/results_table.dart
+++ b/app/lib/components/blocks/results_table.dart
@@ -123,6 +123,16 @@ class ResultsTable extends HookConsumerWidget{
         field: 'error_message',
         type: PlutoColumnType.text()
       ),
+      PlutoColumn(
+        title: 'RandomSeeds',
+        field: 'random_seeds',
+        type: PlutoColumnType.text()
+      ),
+      PlutoColumn(
+        title: 'Scores',
+        field: 'scores',
+        type: PlutoColumnType.text()
+      ),
     ];
     return res;
   }
@@ -142,6 +152,8 @@ class ResultsTable extends HookConsumerWidget{
       'ended_at': PlutoCell(value: ResultModel.datetimeToString(result.ended_at)),
       'game_mode': PlutoCell(value: result.game_mode),
       'error_message': PlutoCell(value: result.error_message),
+      'scores': PlutoCell(value: result.scores.join(", ")),
+      'random_seeds': PlutoCell(value: result.random_seeds.join(", ")),
     };
     return cells;
   }

--- a/app/lib/components/parts/random_seed_form.dart
+++ b/app/lib/components/parts/random_seed_form.dart
@@ -8,63 +8,89 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import '../../view_model/providers.dart';
 
 class RanomSeedForm extends HookConsumerWidget {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final _state = ref.watch(randomSeedsFormStateNotifierProvider);
     final _randomSeedController = useTextEditingController(text: "");
     Size ui_size = MediaQuery.of(context).size;
-    double ui_height = ui_size.height;
-    double ui_width = ui_size.width;
 
-    return Column(
-      children: <Widget>[   
-        Row(
-          children: <Widget>[
-            SizedBox(
-              width: ui_width*0.3,
-              child: TextFormField(
-                decoration: const InputDecoration(
-                  labelText: 'random seeds',
+    return Form(
+      key: _formKey,
+      child: Padding(
+        padding: EdgeInsets.only(left: ui_size.width*0.02, right: ui_size.width*0.02),
+        child: Column(
+          children: <Widget>[   
+            Row(
+              children: <Widget>[
+                SizedBox(
+                  width: ui_size.width*0.3,
+                  child: TextFormField(
+                    decoration: const InputDecoration(
+                      labelText: 'random seeds',
+                    ),
+                    controller: _randomSeedController,
+                    validator: (String? value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please enter some text';
+                      }
+                      $fixnum.Int64 x;
+                      try {
+                        x = $fixnum.Int64(int.parse(value));
+                      } catch (e) {
+                        return 'Please enter Int64 castable value';
+                      }
+                      if (x<0) {
+                        return 'Please enter positive value';
+                      }
+                      return null;
+                    },
+                  ),
                 ),
-                controller: _randomSeedController,
-                validator: (String? value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter some text';
-                  }
-                  return null;
-                },
-              ),
+                IconButton(
+                  icon: Icon(Icons.add_box),
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      ref.read(randomSeedsFormStateNotifierProvider.notifier).addSeed(
+                        $fixnum.Int64(int.parse(_randomSeedController.text))
+                      );
+                    }
+                  },        
+                ),
+              ]
             ),
-            IconButton(
-              icon: Icon(Icons.add_box),
-              onPressed: () {
-                ref.read(randomSeedsFormStateNotifierProvider.notifier).addSeed(
-                  $fixnum.Int64(int.parse(_randomSeedController.text))
-                );
-              },        
+            Container(
+              height: _state.seeds.length*30,
+              child: ListView.builder(
+                itemCount: _state.seeds.length,
+                itemBuilder: (context, index) {
+                  return Container(
+                    height: 30,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: <Widget>[
+                        Text('${index+1}', style: TextStyle(fontSize: 10,)),
+                        SizedBox(width: ui_size.width*0.05,),
+                        SizedBox(
+                          width: ui_size.width*0.2,
+                          child: Text('${_state.seeds[index]}', style: TextStyle(fontSize: 15,))
+                        ),
+                        IconButton(
+                          icon: Icon(Icons.delete, size: 20),
+                          onPressed: () {
+                            ref.read(randomSeedsFormStateNotifierProvider.notifier).removeSeedAt(index);
+                          },
+                        ),
+                      ]
+                    )
+                  );
+                }
+              ),
             ),
           ]
         )
-        // Expanded(
-        //   child: ListView.builder(
-        //     itemCount: _state.length,
-        //     itemBuilder: (context, index) {
-        //       return Card(
-        //         child: ListTile(
-        //           title: Text('${_state[index]}'),
-        //           trailing: IconButton(
-        //             icon: Icon(Icons.delete),
-        //             onPressed: () {
-        //               ref.read(randomSeedsFormStateNotifierProvider.notifier).removeSeedAt(index);
-        //             },
-        //           ),
-        //         ),
-        //       );
-        //     }
-        //   ),
-        // )
-      ]
-    ); 
+      )
+    );
   }
 }

--- a/app/lib/components/parts/random_seed_form.dart
+++ b/app/lib/components/parts/random_seed_form.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:provider/provider.dart';
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+
+import '../../view_model/providers.dart';
+
+class RanomSeedForm extends HookConsumerWidget {
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final _state = ref.watch(randomSeedsFormStateNotifierProvider);
+    final _randomSeedController = useTextEditingController(text: "");
+    Size ui_size = MediaQuery.of(context).size;
+    double ui_height = ui_size.height;
+    double ui_width = ui_size.width;
+
+    return Column(
+      children: <Widget>[   
+        Row(
+          children: <Widget>[
+            SizedBox(
+              width: ui_width*0.3,
+              child: TextFormField(
+                decoration: const InputDecoration(
+                  labelText: 'random seeds',
+                ),
+                controller: _randomSeedController,
+                validator: (String? value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter some text';
+                  }
+                  return null;
+                },
+              ),
+            ),
+            IconButton(
+              icon: Icon(Icons.add_box),
+              onPressed: () {
+                ref.read(randomSeedsFormStateNotifierProvider.notifier).addSeed(
+                  $fixnum.Int64(int.parse(_randomSeedController.text))
+                );
+              },        
+            ),
+          ]
+        )
+        // Expanded(
+        //   child: ListView.builder(
+        //     itemCount: _state.length,
+        //     itemBuilder: (context, index) {
+        //       return Card(
+        //         child: ListTile(
+        //           title: Text('${_state[index]}'),
+        //           trailing: IconButton(
+        //             icon: Icon(Icons.delete),
+        //             onPressed: () {
+        //               ref.read(randomSeedsFormStateNotifierProvider.notifier).removeSeedAt(index);
+        //             },
+        //           ),
+        //         ),
+        //       );
+        //     }
+        //   ),
+        // )
+      ]
+    ); 
+  }
+}

--- a/app/lib/model/form_model.dart
+++ b/app/lib/model/form_model.dart
@@ -11,7 +11,7 @@ class FormModel {
   final int timeout;
   final String predict_weight_path;
   final int trial_num;
-
+  final List<int> random_seeds;
 
   FormModel(
     this.user_name, 
@@ -23,7 +23,8 @@ class FormModel {
     this.game_time,
     this.timeout,
     this.predict_weight_path,
-    this.trial_num
+    this.trial_num,
+    this.random_seeds,
   );
 
   ScoreEvaluationMessage toProtobufMsg(){
@@ -38,6 +39,7 @@ class FormModel {
     msg.timeout = this.timeout;
     msg.predictWeightPath = this.predict_weight_path;
     msg.trialNum = this.trial_num;
+    msg.randomSeeds = this.random_seeds;
     return msg;
   }
 }

--- a/app/lib/model/form_model.dart
+++ b/app/lib/model/form_model.dart
@@ -1,4 +1,5 @@
 import 'score_evaluation_message.pb.dart';
+import 'package:fixnum/fixnum.dart' as $fixnum;
 
 class FormModel {
   final String user_name;
@@ -11,7 +12,7 @@ class FormModel {
   final int timeout;
   final String predict_weight_path;
   final int trial_num;
-  final List<int> random_seeds;
+  final Iterable<$fixnum.Int64> random_seeds;
 
   FormModel(
     this.user_name, 
@@ -39,7 +40,7 @@ class FormModel {
     msg.timeout = this.timeout;
     msg.predictWeightPath = this.predict_weight_path;
     msg.trialNum = this.trial_num;
-    msg.randomSeeds = this.random_seeds;
+    msg.randomSeeds..clear()..addAll(this.random_seeds); // repeated field doesn't have setter
     return msg;
   }
 }

--- a/app/lib/model/result_model.dart
+++ b/app/lib/model/result_model.dart
@@ -58,8 +58,8 @@ class ResultModel{
         stddev_score = map['StdDevScore'],
         max_score = map['MaxScore'],
         min_score = map['MinScore'],
-        random_seeds = map['RandomSeeds'],
-        scores = map["Scores"],
+        random_seeds = fromStringToListInt(map['RandomSeeds']),
+        scores = fromStringToListInt(map["Scores"]),
         error_message = map['ErrorMessage'] ?? "";
     
     Map<String, dynamic> toJson() => {
@@ -116,4 +116,14 @@ String datetimeToString(int? datetime){
   ).toString();
   _res = _datetime.substring(0, _datetime.length-4);
   return _res;
+}
+
+List<int> fromStringToListInt(String? string){
+  if ((string == null)||(string == "")){
+    return [];
+  } else {
+    return string.split(',')
+                 .map<int>((String value) => int.parse(value))
+                 .toList();
+  }
 }

--- a/app/lib/model/result_model.dart
+++ b/app/lib/model/result_model.dart
@@ -15,6 +15,8 @@ class ResultModel{
     final num? stddev_score;
     final int? max_score;
     final int? min_score;
+    final List<int> random_seeds;
+    final List<int> scores;
     final String error_message;
 
     ResultModel(
@@ -34,6 +36,8 @@ class ResultModel{
         this.stddev_score,
         this.max_score,
         this.min_score,
+        this.random_seeds,
+        this.scores,
         this.error_message,
     );
     
@@ -54,6 +58,8 @@ class ResultModel{
         stddev_score = map['StdDevScore'],
         max_score = map['MaxScore'],
         min_score = map['MinScore'],
+        random_seeds = map['RandomSeeds'],
+        scores = map["Scores"],
         error_message = map['ErrorMessage'] ?? "";
     
     Map<String, dynamic> toJson() => {
@@ -73,6 +79,8 @@ class ResultModel{
         'stddev_score': stddev_score,
         'max_score': max_score,
         'min_score': min_score,
+        'random_seeds': random_seeds,
+        "scores": scores,
         'error_message': error_message
     };
     List<String> toCsv() => [
@@ -92,6 +100,8 @@ class ResultModel{
         '$stddev_score',
         '$max_score',
         '$min_score',
+        random_seeds.join(","),
+        scores.join(","),
         error_message
       ];    
 }

--- a/app/lib/model/score_evaluation_message.pb.dart
+++ b/app/lib/model/score_evaluation_message.pb.dart
@@ -7,6 +7,7 @@
 
 import 'dart:core' as $core;
 
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'score_evaluation_message.pbenum.dart';
@@ -27,6 +28,7 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
     ..a<$core.int>(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdAt', $pb.PbFieldType.O3)
     ..aOS(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..p<$fixnum.Int64>(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'randomSeeds', $pb.PbFieldType.KU6)
     ..hasRequiredFields = false
   ;
 
@@ -44,6 +46,7 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     $core.String? id,
     $core.int? createdAt,
     $core.String? name,
+    $core.Iterable<$fixnum.Int64>? randomSeeds,
   }) {
     final _result = create();
     if (repositoryUrl != null) {
@@ -81,6 +84,9 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     }
     if (name != null) {
       _result.name = name;
+    }
+    if (randomSeeds != null) {
+      _result.randomSeeds.addAll(randomSeeds);
     }
     return _result;
   }
@@ -212,5 +218,8 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
   $core.bool hasName() => $_has(11);
   @$pb.TagNumber(12)
   void clearName() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.List<$fixnum.Int64> get randomSeeds => $_getList(12);
 }
 

--- a/app/lib/model/score_evaluation_message.pbjson.dart
+++ b/app/lib/model/score_evaluation_message.pbjson.dart
@@ -24,6 +24,7 @@ const ScoreEvaluationMessage$json = const {
     const {'1': 'timeout', '3': 7, '4': 1, '5': 5, '10': 'timeout'},
     const {'1': 'predict_weight_path', '3': 8, '4': 1, '5': 9, '10': 'predictWeightPath'},
     const {'1': 'trial_num', '3': 9, '4': 1, '5': 5, '10': 'trialNum'},
+    const {'1': 'random_seeds', '3': 13, '4': 3, '5': 4, '10': 'randomSeeds'},
   ],
   '4': const [ScoreEvaluationMessage_GameLevel$json],
   '8': const [
@@ -46,4 +47,4 @@ const ScoreEvaluationMessage_GameLevel$json = const {
 };
 
 /// Descriptor for `ScoreEvaluationMessage`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List scoreEvaluationMessageDescriptor = $convert.base64Decode('ChZTY29yZUV2YWx1YXRpb25NZXNzYWdlEhcKBG5hbWUYDCABKAlIAFIEbmFtZYgBARITCgJpZBgKIAEoCUgBUgJpZIgBARIiCgpjcmVhdGVkX2F0GAsgASgFSAJSCWNyZWF0ZWRBdIgBARIlCg5yZXBvc2l0b3J5X3VybBgBIAEoCVINcmVwb3NpdG9yeVVybBIWCgZicmFuY2gYAiABKAlSBmJyYW5jaBIjCg1kcm9wX2ludGVydmFsGAMgASgFUgxkcm9wSW50ZXJ2YWwSQAoFbGV2ZWwYBCABKA4yKi50dXRvcmlhbC5TY29yZUV2YWx1YXRpb25NZXNzYWdlLkdhbWVMZXZlbFIFbGV2ZWwSGwoJZ2FtZV9tb2RlGAUgASgJUghnYW1lTW9kZRIbCglnYW1lX3RpbWUYBiABKAVSCGdhbWVUaW1lEhgKB3RpbWVvdXQYByABKAVSB3RpbWVvdXQSLgoTcHJlZGljdF93ZWlnaHRfcGF0aBgIIAEoCVIRcHJlZGljdFdlaWdodFBhdGgSGwoJdHJpYWxfbnVtGAkgASgFUgh0cmlhbE51bSI8CglHYW1lTGV2ZWwSCAoEWkVSTxAAEgcKA09ORRABEgcKA1RXTxACEgkKBVRIUkVFEAMSCAoERk9VUhAEQgcKBV9uYW1lQgUKA19pZEINCgtfY3JlYXRlZF9hdA==');
+final $typed_data.Uint8List scoreEvaluationMessageDescriptor = $convert.base64Decode('ChZTY29yZUV2YWx1YXRpb25NZXNzYWdlEhcKBG5hbWUYDCABKAlIAFIEbmFtZYgBARITCgJpZBgKIAEoCUgBUgJpZIgBARIiCgpjcmVhdGVkX2F0GAsgASgFSAJSCWNyZWF0ZWRBdIgBARIlCg5yZXBvc2l0b3J5X3VybBgBIAEoCVINcmVwb3NpdG9yeVVybBIWCgZicmFuY2gYAiABKAlSBmJyYW5jaBIjCg1kcm9wX2ludGVydmFsGAMgASgFUgxkcm9wSW50ZXJ2YWwSQAoFbGV2ZWwYBCABKA4yKi50dXRvcmlhbC5TY29yZUV2YWx1YXRpb25NZXNzYWdlLkdhbWVMZXZlbFIFbGV2ZWwSGwoJZ2FtZV9tb2RlGAUgASgJUghnYW1lTW9kZRIbCglnYW1lX3RpbWUYBiABKAVSCGdhbWVUaW1lEhgKB3RpbWVvdXQYByABKAVSB3RpbWVvdXQSLgoTcHJlZGljdF93ZWlnaHRfcGF0aBgIIAEoCVIRcHJlZGljdFdlaWdodFBhdGgSGwoJdHJpYWxfbnVtGAkgASgFUgh0cmlhbE51bRIhCgxyYW5kb21fc2VlZHMYDSADKARSC3JhbmRvbVNlZWRzIjwKCUdhbWVMZXZlbBIICgRaRVJPEAASBwoDT05FEAESBwoDVFdPEAISCQoFVEhSRUUQAxIICgRGT1VSEARCBwoFX25hbWVCBQoDX2lkQg0KC19jcmVhdGVkX2F0');

--- a/app/lib/repository/db_repository.dart
+++ b/app/lib/repository/db_repository.dart
@@ -21,9 +21,11 @@ class DBRepositoryImpl implements DBRepository {
     http.Response result = await http.get(uri);
     var _map = convert.jsonDecode(result.body);
     List<dynamic> items = _map['Items'];
+    print(items);
     List<ResultModel> results = items.map(
         (var item) => ResultModel.fromJson(item)
     ).toList();
+
     return results;
   }
 

--- a/app/lib/view_model/form_view_model.dart
+++ b/app/lib/view_model/form_view_model.dart
@@ -95,4 +95,8 @@ class FormStateNotifier extends StateNotifier<FormState> {
   void setFormValidationErrorState(){
     state = FormError("form validation error\nfix invalid forms");
   }
+
+  void setRandomFormValidationErrorState(){
+    state = FormError("random seed form validation error\nnumber of random seeds must equals to trials");
+  }
 }

--- a/app/lib/view_model/providers.dart
+++ b/app/lib/view_model/providers.dart
@@ -1,8 +1,11 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:fixnum/fixnum.dart' as $fixnum;
+
 
 import 'form_view_model.dart' as FormViewModel;
 import 'results_view_model.dart' as ResultsViewModel;
 import 'entries_view_model.dart' as EntriesViewModel;
+import 'random_seeds_form_view_model.dart' as RandomSeedsFormViewModel;
 import '../model/result_model.dart' as ResultModel;
 import '../model/entry_model.dart' as EntryModel;
 import '../repository/form_repository.dart';
@@ -26,4 +29,7 @@ final entriesStateNotifierProvider = StateNotifierProvider<EntriesViewModel.Entr
     ref.watch(dbRepositoryProvider),
     ref.watch(fileRepositoryProvider)
   ),
+);
+final randomSeedsFormStateNotifierProvider = StateNotifierProvider<RandomSeedsFormViewModel.RandomSeedsFormStateNotifier, RandomSeedsFormViewModel.RandomSeedsFormModel>(
+  (ref) => RandomSeedsFormViewModel.RandomSeedsFormStateNotifier()
 );

--- a/app/lib/view_model/random_seeds_form_view_model.dart
+++ b/app/lib/view_model/random_seeds_form_view_model.dart
@@ -1,0 +1,49 @@
+import 'package:state_notifier/state_notifier.dart';
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+
+class RandomSeedsFormModel {
+    final bool _isEnabledSeedConfiguration;
+    final List<$fixnum.Int64> _seeds;
+
+    RandomSeedsFormModel(
+        this._isEnabledSeedConfiguration,
+        this._seeds,
+    );
+
+    List<$fixnum.Int64> get seeds => _isEnabledSeedConfiguration ? _seeds : [];
+    bool get isEnabledSeedConfiguration => _isEnabledSeedConfiguration;
+}
+
+class RandomSeedsFormStateNotifier extends StateNotifier<RandomSeedsFormModel> {
+    RandomSeedsFormStateNotifier() : super(RandomSeedsFormModel(false, [])){
+    }
+    void toggleIsEnabled(bool? _){
+        state = RandomSeedsFormModel(
+            !state.isEnabledSeedConfiguration,
+            state.seeds,
+        );
+    }
+
+    void addSeed($fixnum.Int64 _seed) {
+        state = RandomSeedsFormModel(
+            state.isEnabledSeedConfiguration,
+            [...state.seeds, _seed]
+        );
+    }
+
+    void removeSeedAt(int _index) {
+        int i = 0;
+        List<$fixnum.Int64> new_seeds = [];
+        for (final $fixnum.Int64 _seed in state.seeds){
+            if (i != _index){
+                new_seeds.add(_seed);
+            }
+            i++;
+        }
+        state = RandomSeedsFormModel(
+            state.isEnabledSeedConfiguration,
+            new_seeds,
+        );
+    }
+}

--- a/protobuf/score_evaluation_message.pb.dart
+++ b/protobuf/score_evaluation_message.pb.dart
@@ -7,6 +7,7 @@
 
 import 'dart:core' as $core;
 
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'score_evaluation_message.pbenum.dart';
@@ -27,6 +28,7 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
     ..a<$core.int>(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdAt', $pb.PbFieldType.O3)
     ..aOS(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..p<$fixnum.Int64>(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'randomSeeds', $pb.PbFieldType.KU6)
     ..hasRequiredFields = false
   ;
 
@@ -44,6 +46,7 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     $core.String? id,
     $core.int? createdAt,
     $core.String? name,
+    $core.Iterable<$fixnum.Int64>? randomSeeds,
   }) {
     final _result = create();
     if (repositoryUrl != null) {
@@ -81,6 +84,9 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
     }
     if (name != null) {
       _result.name = name;
+    }
+    if (randomSeeds != null) {
+      _result.randomSeeds.addAll(randomSeeds);
     }
     return _result;
   }
@@ -212,5 +218,8 @@ class ScoreEvaluationMessage extends $pb.GeneratedMessage {
   $core.bool hasName() => $_has(11);
   @$pb.TagNumber(12)
   void clearName() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.List<$fixnum.Int64> get randomSeeds => $_getList(12);
 }
 

--- a/protobuf/score_evaluation_message.pbjson.dart
+++ b/protobuf/score_evaluation_message.pbjson.dart
@@ -24,6 +24,7 @@ const ScoreEvaluationMessage$json = const {
     const {'1': 'timeout', '3': 7, '4': 1, '5': 5, '10': 'timeout'},
     const {'1': 'predict_weight_path', '3': 8, '4': 1, '5': 9, '10': 'predictWeightPath'},
     const {'1': 'trial_num', '3': 9, '4': 1, '5': 5, '10': 'trialNum'},
+    const {'1': 'random_seeds', '3': 13, '4': 3, '5': 4, '10': 'randomSeeds'},
   ],
   '4': const [ScoreEvaluationMessage_GameLevel$json],
   '8': const [
@@ -46,4 +47,4 @@ const ScoreEvaluationMessage_GameLevel$json = const {
 };
 
 /// Descriptor for `ScoreEvaluationMessage`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List scoreEvaluationMessageDescriptor = $convert.base64Decode('ChZTY29yZUV2YWx1YXRpb25NZXNzYWdlEhcKBG5hbWUYDCABKAlIAFIEbmFtZYgBARITCgJpZBgKIAEoCUgBUgJpZIgBARIiCgpjcmVhdGVkX2F0GAsgASgFSAJSCWNyZWF0ZWRBdIgBARIlCg5yZXBvc2l0b3J5X3VybBgBIAEoCVINcmVwb3NpdG9yeVVybBIWCgZicmFuY2gYAiABKAlSBmJyYW5jaBIjCg1kcm9wX2ludGVydmFsGAMgASgFUgxkcm9wSW50ZXJ2YWwSQAoFbGV2ZWwYBCABKA4yKi50dXRvcmlhbC5TY29yZUV2YWx1YXRpb25NZXNzYWdlLkdhbWVMZXZlbFIFbGV2ZWwSGwoJZ2FtZV9tb2RlGAUgASgJUghnYW1lTW9kZRIbCglnYW1lX3RpbWUYBiABKAVSCGdhbWVUaW1lEhgKB3RpbWVvdXQYByABKAVSB3RpbWVvdXQSLgoTcHJlZGljdF93ZWlnaHRfcGF0aBgIIAEoCVIRcHJlZGljdFdlaWdodFBhdGgSGwoJdHJpYWxfbnVtGAkgASgFUgh0cmlhbE51bSI8CglHYW1lTGV2ZWwSCAoEWkVSTxAAEgcKA09ORRABEgcKA1RXTxACEgkKBVRIUkVFEAMSCAoERk9VUhAEQgcKBV9uYW1lQgUKA19pZEINCgtfY3JlYXRlZF9hdA==');
+final $typed_data.Uint8List scoreEvaluationMessageDescriptor = $convert.base64Decode('ChZTY29yZUV2YWx1YXRpb25NZXNzYWdlEhcKBG5hbWUYDCABKAlIAFIEbmFtZYgBARITCgJpZBgKIAEoCUgBUgJpZIgBARIiCgpjcmVhdGVkX2F0GAsgASgFSAJSCWNyZWF0ZWRBdIgBARIlCg5yZXBvc2l0b3J5X3VybBgBIAEoCVINcmVwb3NpdG9yeVVybBIWCgZicmFuY2gYAiABKAlSBmJyYW5jaBIjCg1kcm9wX2ludGVydmFsGAMgASgFUgxkcm9wSW50ZXJ2YWwSQAoFbGV2ZWwYBCABKA4yKi50dXRvcmlhbC5TY29yZUV2YWx1YXRpb25NZXNzYWdlLkdhbWVMZXZlbFIFbGV2ZWwSGwoJZ2FtZV9tb2RlGAUgASgJUghnYW1lTW9kZRIbCglnYW1lX3RpbWUYBiABKAVSCGdhbWVUaW1lEhgKB3RpbWVvdXQYByABKAVSB3RpbWVvdXQSLgoTcHJlZGljdF93ZWlnaHRfcGF0aBgIIAEoCVIRcHJlZGljdFdlaWdodFBhdGgSGwoJdHJpYWxfbnVtGAkgASgFUgh0cmlhbE51bRIhCgxyYW5kb21fc2VlZHMYDSADKARSC3JhbmRvbVNlZWRzIjwKCUdhbWVMZXZlbBIICgRaRVJPEAASBwoDT05FEAESBwoDVFdPEAISCQoFVEhSRUUQAxIICgRGT1VSEARCBwoFX25hbWVCBQoDX2lkQg0KC19jcmVhdGVkX2F0');

--- a/protobuf/score_evaluation_message.proto
+++ b/protobuf/score_evaluation_message.proto
@@ -15,6 +15,7 @@ message ScoreEvaluationMessage {
   int32 timeout = 7;
   string predict_weight_path = 8;
   int32 trial_num = 9;
+  repeated uint64 random_seeds = 13; // dynamically sized array, length can be zero 
 
   enum GameLevel {
     ZERO = 0; // endless


### PR DESCRIPTION
https://github.com/TetrisChallenge/tetris_score_server/pull/81
上記PRに対するフロント側の変更対応
- ランダムシードの指定ができる
- ランダムシード指定をするときは、試行回数とランダムシードの個数は同じでなければならない
- ランダムシード値は64bitで表現可能な数値である